### PR TITLE
Fixes ErrorException in Laravel 5.5

### DIFF
--- a/src/Laravel55Compatibility.php
+++ b/src/Laravel55Compatibility.php
@@ -9,12 +9,13 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
  */
 trait Laravel55Compatibility {
     /**
-     * @param array $headers
-     * @param array $rows
-     * @internal param string $style
+     * @param $headers
+     * @param $rows
+     * @param string $style
+     * @param array $columnStyles
      * @return void
      */
-    public function table($headers, $rows, $style = 'default') {
+    public function table($headers, $rows, $style = 'default', array $columnStyles = []) {
         try {
             $table = $this->getHelperSet()->get('table');
         } catch (InvalidArgumentException $error) {


### PR DESCRIPTION
https://github.com/backup-manager/laravel/issues/88
```
[ErrorException]
  Declaration of BackupManager\Laravel\Laravel55Compatibility::table($headers, $rows, $style = 'default') should be compati
  ble with Illuminate\Console\Command::table($headers, $rows, $tableStyle = 'default', array $columnStyles = Array)
```